### PR TITLE
Remove tax meta when user is deleted from subsite

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -17,6 +17,7 @@ function bootstrap() {
 	add_action( 'set_user_role', __NAMESPACE__ . '\\set_user_role', 10, 3 );
 	add_action( 'init', __NAMESPACE__ . '\\register_roles_taxonomies' );
 	add_filter( 'pre_count_users', __NAMESPACE__ . '\\get_count_users', 10, 3 );
+	add_action( 'remove_user_from_blog', __NAMESPACE__ . '\\remove_user_tax_meta', 10, 2 );
 
 	if ( defined( 'WP_CLI' ) && WP_CLI ) {
 		require_once __DIR__ . '/class-cli-command.php';
@@ -337,4 +338,33 @@ function set_wp_user_query_count_total( $null, WP_User_Query $query ) {
 	$query->total_users = $count;
 
 	return $null;
+}
+
+/**
+ * Remove user tax meta when deleting user from subsite.
+ *
+ * @param int $user_id ID of the user being removed.
+ * @param int $blog_id ID of the blog the user is being removed from. Default 0.
+ * @return void
+ */
+function remove_user_tax_meta( int $user_id, int $blog_id ) : void {
+	$restore_blog = false;
+	if ( $blog_id !== get_current_blog_id() ) {
+		switch_to_blog( $blog_id );
+		$restore_blog = true;
+	}
+
+	$user_roles = wp_get_object_terms( $user_id, ROLES_TAXONOMY );
+	array_map( function( $user_role ) use ( $user_id ) {
+		wp_remove_object_terms( $user_id, $user_role->term_id, ROLES_TAXONOMY, true );
+	}, $user_roles );
+
+	$user_levels = wp_get_object_terms( $user_id, USER_LEVELS_TAXONOMY );
+	array_map( function( $user_level ) use ( $user_id ) {
+		wp_remove_object_terms( $user_id, $user_level->term_id, USER_LEVELS_TAXONOMY, true );
+	}, $user_levels );
+
+	if ( $restore_blog ) {
+		restore_current_blog();
+	}
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -355,14 +355,14 @@ function remove_user_tax_meta( int $user_id, int $blog_id ) : void {
 	}
 
 	$user_roles = wp_get_object_terms( $user_id, ROLES_TAXONOMY );
-	array_map( function( $user_role ) use ( $user_id ) {
+	foreach( $user_roles as $user_role ) {
 		wp_remove_object_terms( $user_id, $user_role->term_id, ROLES_TAXONOMY, true );
-	}, $user_roles );
+	}
 
 	$user_levels = wp_get_object_terms( $user_id, USER_LEVELS_TAXONOMY );
-	array_map( function( $user_level ) use ( $user_id ) {
+	foreach( $user_levels as $user_level ) {
 		wp_remove_object_terms( $user_id, $user_level->term_id, USER_LEVELS_TAXONOMY, true );
-	}, $user_levels );
+	}
 
 	if ( $restore_blog ) {
 		restore_current_blog();


### PR DESCRIPTION
@joehoyle so currently we don't properly delete the user from the sub-site, this was reported by the client on a project. This PR resolves that issue by removing the meta from the custom taxonomies. 

Before fix - You can see the user doesn't get removed properly
![before](https://user-images.githubusercontent.com/15369210/90577855-33cce000-e205-11ea-9187-2685763861f1.gif)

After fix - Removes the user from the site.
![after](https://user-images.githubusercontent.com/15369210/90577881-40513880-e205-11ea-93c8-60c41903f46e.gif)
