### PR TITLE
Fix PHP8 deprecation warning for optional parameter

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -292,7 +292,7 @@ function remove_user_role( int $user_id, ?string $role ) {
  * @param integer $blog_id
  * @return array
  */
-function get_count_users( $users = null, string $strategy, int $blog_id ) {
+function get_count_users( $users, string $strategy, int $blog_id ) {
 	if ( $users ) {
 		return $users;
 	}


### PR DESCRIPTION
Optional parameters should not precede required parameters.

This causes a deprecation warning in PHP 8.

Fixes #10